### PR TITLE
new dynamic configuration options

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,49 @@
+const CONFIG = {
+    proxyDomain: process.env.HIGHFIVE_API_SERVER || 'arielflash-server.azurewebsites.net',
+    hostPort: process.env.PORT || '2368',
+    enableMocks: true,
+    enableProxy: true
+};
+
+const ENV_CONFIGS = {
+    production: {
+
+    },
+    development: {
+
+    }
+};
+
+const TARGET_CONFIG = {
+    production: {
+
+    },
+    development: {
+        proxyDomain: 'arielflash-server.azurewebsites.net',
+        enableMocks: false,
+        enableProxy: true
+    },
+    qa: {
+
+    },
+    uat: {
+
+    },
+    mock: {
+        enableMocks: true,
+        enableProxy: false
+    }
+};
+
+//assign overrides based on environment
+Object.assign(CONFIG, ENV_CONFIGS[process.env.NODE_ENV || 'development']);
+
+//assign overrides based on command line targets (ie --mock)
+process.argv.forEach(arg => {
+    arg = arg.replace('--', '');
+    if (TARGET_CONFIG.hasOwnProperty(arg)) Object.assign(CONFIG, TARGET_CONFIG[arg]);
+});
+
+console.log(JSON.stringify(CONFIG));
+
+module.exports = CONFIG;

--- a/json-server/mock-redirect.js
+++ b/json-server/mock-redirect.js
@@ -1,4 +1,7 @@
+let config = require('../config');
+
 //write a function that takes a request input and returns true if it should be mocked to json server otherwise fall through
+//if config.enableProxy is disabled and we hit local api, we will mock everything
 const mockMatches = [
     req => req.url.includes('/api/recognitions'),
     req => req.url.includes('/api/sampleUser')
@@ -10,7 +13,10 @@ module.exports = function (app) {
         jsonRouter = jsonServer.router(path.join(__dirname, 'db.json'));
 
     app.use((req, res, next) => {
-        if (!req.url.match(/^\/mock/) && mockMatches.find(match => match(req))) {
+        let isApi = req.url.match(/^\/api/),
+            isMock = req.url.match(/^\/mock/);
+
+        if (isApi && !isMock && (!config.enableProxy && mockMatches.find(match => match(req)))) {
             console.log(`redirecting request ${req.url} to /mock${req.url} on mock json server`);
             res.redirect(`/mock${req.url}`);
         }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coverage": "babel-node node_modules/babel-istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha ./test/index.jsx",
     "coverage-clean": "npm run rimraf -- test-artifacts/coverage",
     "coverage-open": "open coverage/index.html",
-    "delayed-open": "sleep 5 && open http://localhost:$npm_package_config_clientPort",
+    "delayed-open": "sleep 5 && open http://localhost:2368",
     "deploy": "npm run build",
     "e2e": "node \"node_modules/protractor/bin/protractor\" protractor.conf.js",
     "e2e-test-server": "concurrently --kill-others \"npm run server\" \"webpack-dev-server \"",
@@ -138,11 +138,5 @@
     "webpack-hot-middleware": "2.10.0",
     "webpack-load-plugins": "0.1.2",
     "yargs": "4.7.1"
-  },
-  "config": {
-    "clientPort": "2368",
-    "serverEndpoint": "arielflash-server.azurewebsites.net",
-    "apiPort": "3000",
-    "baseURL": "/api/"
   }
 }

--- a/server.js
+++ b/server.js
@@ -8,36 +8,38 @@ let express = require('express'),
     serveStatic = require('serve-static'),
     path = require('path'),
     app = express(),
+    config = require('./config'),
     mock = require('./json-server/mock-redirect'),
-    packageJson = require('./package.json'),
-    proxyDomain = process.env.HIGHFIVE_API_SERVER || packageJson.config.serverEndpoint;
+    packageJson = require('./package.json');
 
 //use mocks where appropriate, then fall back to real thing if mocks aren't there
-mock(app);
+if (config.enableMocks) mock(app);
 
 //proxy /api locally to the designated endpoint that should be passed in as an environment variable
-app.use('/api', proxy(proxyDomain, {
-    decorateRequest: (proxyReq, originalReq) => {
-        //FIXME: if we allow gzip compress, IIS in Azure sitting in front of Node is blowing up on a 502
-        //I think this needs a fix to web.config to handle this, may need a web.config here to override
-        delete proxyReq.headers['accept-encoding'];
-        return proxyReq;
-    },
-    intercept: (rsp, data, req, res, callback) => {
-        if (res._headers['set-cookie']) {
-            //fix any set cookie headers specific to the proxied domain back to the local domain
-            let localDomain = req.headers.host.substr(0, req.headers.host.indexOf(':') || req.headers.length);
-            res._headers['set-cookie'] = JSON.parse(JSON.stringify(res._headers['set-cookie']).replace(proxyDomain, localDomain));
+if (config.enableProxy) {
+    app.use('/api', proxy(config.proxyDomain, {
+        decorateRequest: (proxyReq, originalReq) => {
+            //FIXME: if we allow gzip compress, IIS in Azure sitting in front of Node is blowing up on a 502
+            //I think this needs a fix to web.config to handle this, may need a web.config here to override
+            delete proxyReq.headers['accept-encoding'];
+            return proxyReq;
+        },
+        intercept: (rsp, data, req, res, callback) => {
+            if (res._headers['set-cookie']) {
+                //fix any set cookie headers specific to the proxied domain back to the local domain
+                let localDomain = req.headers.host.substr(0, req.headers.host.indexOf(':') || req.headers.length);
+                res._headers['set-cookie'] = JSON.parse(JSON.stringify(res._headers['set-cookie']).replace(config.proxyDomain, localDomain));
+            }
+            callback(null, data);
+        },
+        forwardPath: (req) => {
+            //forward to proxy with same url including the prefix
+            return `/api${url.parse(req.url).path}`;
         }
-        callback(null, data);
-    },
-    forwardPath: (req) => {
-        //forward to proxy with same url including the prefix
-        return `/api${url.parse(req.url).path}`;
-    }
-}));
+    }));
+}
 
-app.set('port', process.env.PORT || packageJson.config.clientPort);
+app.set('port', config.hostPort);
 app.use(compression());
 app.use(serveStatic('dist'));
 app.get('*', (request, response, next) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,8 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 
-var npmConfig = require("./package.json").config;
-var hotMiddleWarePort = npmConfig.clientPort;
+var config = require("./config");
+var hotMiddleWarePort = config.hostPort;
 
 
 var DEFAULT_TARGET = 'app';


### PR DESCRIPTION
There is a new export called "config" which has default options that are then overriden by environment and targets. Targets are used by command line arguments thrown at any command (ie npm start --mock).

* `npm start` - By default, it will try to auto discover based on environment variables and enabling the proxy and mocks. You can white list mocks for endpoints that are not yet implemented and let all other implemented endpoints fall through to API proxy against the target server.
* `npm start --development` - This will specifically target the development server endpoint via the proxy and disable all mocks.
* `npm start --mock` - This will specifically target the json mock server and disable the remote server proxy.