### PR TITLE
F1-33 Fix Font Error

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HIGHFIVE</title>
     <link href="https://fonts.googleapis.com/css?family=Merriweather|Source+Sans+Pro" rel="stylesheet">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -144,23 +144,15 @@ module.exports = (function makeWebpackConfig() {
                 include: path.join(__dirname, 'src')
             },
             {
-                test: /\.woff\d?(\?.+)?$/,
-                loader: 'url?limit=10000&mimetype=application/font-woff'
-            },
-            {
-                test: /\.ttf(\?.+)?$/,
-                loader: 'url?limit=10000&mimetype=application/octet-stream'
-            },
-            {
-                test: /\.eot(\?.+)?$/,
-                loader: 'file',
+                test: /\.(woff|ttf|eot)\d?(\?.+)?$/,
+                loader: 'file'
             },
             {
                 test: /\.svg(\?.+)?$/,
                 loader: 'url?limit=10000&mimetype=image/svg+xml'
             },
             {
-                test: /\.(png|jpg|jpeg|gif|woff)$/,
+                test: /\.(png|jpg|jpeg|gif)$/,
                 loader: 'url-loader?limit=8192'
             },
             {


### PR DESCRIPTION
* Webpack config set to embedded fonts with dataURI, disabled to produce external fonts reducing size of JS file and eliminating decoding error
* Fixed issue with UTF-8/ASCII decoding of the "x" close icon in modals