### PR TITLE
annoying style flicker

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,6 +117,7 @@ module.exports = (function makeWebpackConfig() {
      * List: http://webpack.github.io/docs/list-of-loaders.html
      * This handles most of the magic responsible for converting modules
      */
+    let cssSourceMap = ENV === 'build' ? '' : 'sourceMap';
     config.module = {
         preLoaders: isTestEnv || isE2ETestEnv ? [] : [{test: /\.js$/, loader: 'eslint'}],
         exprContextCritical : false,
@@ -131,7 +132,7 @@ module.exports = (function makeWebpackConfig() {
             },
             {
                 test: /\.scss/,
-                loader: 'style-loader!css-loader?sourceMap!postcss-loader?sourceMap!sass-loader?sourceMap'
+                loader: `style-loader!css-loader?${cssSourceMap}!postcss-loader?${cssSourceMap}!sass-loader?${cssSourceMap}`
             },
             {
                 test: /\.json$/,


### PR DESCRIPTION
Per style-loader docs:

```
Note about source maps support and assets referenced with url: when style loader is used with ?sourceMap option, the CSS modules will be generated as Blobs, so relative paths don't work (they would be relative to chrome:blob or chrome:devtools). In order for assets to maintain correct paths setting output.publicPath property of webpack configuration must be set, so that absolute paths are generated.
```
So need to disable source maps for prod builds, which they should have been anyways